### PR TITLE
Add KryoSerializer which is faster and more space saving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,15 @@
       <version>2.9.0</version>
       <scope>compile</scope>
     </dependency>
+    
+    <!--
+     | kryo dependencies
+    -->
+    <dependency>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>kryo</artifactId>
+        <version>4.0.1</version>
+    </dependency>
 
     <!--
      | trick to fix javadoc generation

--- a/src/main/java/org/mybatis/caches/redis/JDKSerializer.java
+++ b/src/main/java/org/mybatis/caches/redis/JDKSerializer.java
@@ -1,0 +1,44 @@
+package org.mybatis.caches.redis;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.apache.ibatis.cache.CacheException;
+
+public class JDKSerializer {
+	
+	private JDKSerializer() {
+		// prevent instantiation
+	}
+	
+	
+	public static byte[] serialize(Object object) {
+        ObjectOutputStream oos = null;
+        ByteArrayOutputStream baos = null;
+        try {
+            baos = new ByteArrayOutputStream();
+            oos = new ObjectOutputStream(baos);
+            oos.writeObject(object);
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+
+    public static Object unserialize(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        ByteArrayInputStream bais = null;
+        try {
+            bais = new ByteArrayInputStream(bytes);
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            return ois.readObject();
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+
+}

--- a/src/test/java/org/mybatis/caches/redis/RedisTestCase.java
+++ b/src/test/java/org/mybatis/caches/redis/RedisTestCase.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2016 the original author or authors.
+ *    Copyright 2015-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+
 
 /**
  * Test with Ubuntu
@@ -80,5 +82,6 @@ public final class RedisTestCase {
   public void shouldVerifyToString() {
     assertEquals("Redis {REDIS}", cache.toString());
   }
+  
 
 }

--- a/src/test/java/org/mybatis/caches/redis/SerializerTestCase.java
+++ b/src/test/java/org/mybatis/caches/redis/SerializerTestCase.java
@@ -1,0 +1,65 @@
+package org.mybatis.caches.redis;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SerializerTestCase {
+
+	int max=1000000;
+	  
+	@Test
+	public void testKryoSerialize() {
+		SimpleBean rawSimpleBean=new SimpleBean();
+		
+		for(int i=0;i!=max;++i)
+		{
+			KryoSerializer.serialize(rawSimpleBean);
+		}
+			
+		byte[] serialBytes=KryoSerializer.serialize(rawSimpleBean);
+		System.out.println("Byte size after kryo serialize "+serialBytes.length);
+		SimpleBean unserializeSimpleBean=(SimpleBean) KryoSerializer.unserialize(serialBytes);
+		
+		for(int i=0;i!=max;++i)
+		{
+			KryoSerializer.unserialize(serialBytes);
+		}
+		
+		assertEquals(rawSimpleBean, unserializeSimpleBean);
+
+	}
+  
+	@Test
+	public void testJDKSerialize() {
+		SimpleBean rawSimpleBean=new SimpleBean();
+		
+		for(int i=0;i!=max;++i)
+		{
+			JDKSerializer.serialize(rawSimpleBean);
+		}
+			
+		byte[] serialBytes=JDKSerializer.serialize(rawSimpleBean);
+		System.out.println("Byte size after jdk serialize "+serialBytes.length);
+		SimpleBean unserializeSimpleBean=(SimpleBean) JDKSerializer.unserialize(serialBytes);
+		
+		for(int i=0;i!=max;++i)
+		{
+			JDKSerializer.unserialize(serialBytes);
+		}
+		
+		assertEquals(rawSimpleBean, unserializeSimpleBean);
+
+	}
+	
+	@Test
+	public void testSerializeUtil() {
+		SimpleBean rawSimpleBean=new SimpleBean();
+	
+		byte[] serialBytes=SerializeUtil.serialize(rawSimpleBean);
+		SimpleBean unserializeSimpleBean=(SimpleBean) SerializeUtil.unserialize(serialBytes);
+		
+		assertEquals(rawSimpleBean, unserializeSimpleBean);
+
+	}
+}

--- a/src/test/java/org/mybatis/caches/redis/SimpleBean.java
+++ b/src/test/java/org/mybatis/caches/redis/SimpleBean.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2015-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.caches.redis;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class SimpleBean implements Serializable{
+	/**
+	 * 
+	 */
+//	private static final long serialVersionUID = 1L;
+	String name;
+	int age;
+	int grade;
+	String sex;
+	ArrayList<String> courses;
+	
+	
+	public SimpleBean() {
+		// TODO Auto-generated constructor stub
+		this.name="Kobe Bryant";
+		this.age=40;
+		this.grade=12;
+		this.sex="MALE";
+		this.courses=new ArrayList<String>();
+		this.courses.add("English");
+		this.courses.add("Math");
+		this.courses.add("Physics");
+	}
+	
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public int getAge() {
+		return age;
+	}
+	public void setAge(int age) {
+		this.age = age;
+	}
+	public int getGrade() {
+		return grade;
+	}
+	public void setGrade(int grade) {
+		this.grade = grade;
+	}
+	public String getSex() {
+		return sex;
+	}
+	public void setSex(String sex) {
+		this.sex = sex;
+	}
+
+	@Override
+	public String toString() {
+		return "StudentInfo [name=" + name + ", age=" + age + ", grade="
+				+ grade + ", sex=" + sex + "]";
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		// TODO Auto-generated method stub
+		if(obj==null)
+			return false;
+		if(!obj.getClass().equals(SimpleBean.class))
+			return false;
+		return this.toString().equals(obj.toString());
+	}
+	
+	
+	
+	
+}


### PR DESCRIPTION
As kryo is a  Java binary serialization library, which is fast, efficient, automatic, I replace JDK serializer with kryo serializer as default. When  kryo serializer fails, JDK serializer is used as a fallback.

Changes are as following:
KryoSerializer.java(new): implement for kryo serializer
JDKSerializer.java(new):implement for jdk serializer same as past SerializeUtil.java
SerializeUtil.java(modified):main class to call kryo serializer(first) and jdk serializer(fallback)
SerializerTestCase.java(new):test case for kryo serializer and jdk serializer
SimpleBean.java(new):simple bean for SerializerTestCase
pom.xml: add kryo dependency

Benchmark:
For test cases in SerializerTestCase.java runs on my desktop(Windows 7 64bit, Intel i5 CPU, 8GB RAM),serialize and unserialize simpleBean for 1000,000 times:
KryoSerializer:2.197s 
JDKSerializer:14.139s
And bytes size after serialize  is:
KryoSerializer:68
JDKSerializer:253

I hope this patch will be merged. 




