### PR TITLE
[kryo] Upgrade kryo to 5.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
      | kryo dependencies
     -->
     <dependency>
-      <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
-      <version>4.0.3</version>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo5</artifactId>
+      <version>5.5.0</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/src/main/java/org/mybatis/caches/redis/KryoSerializer.java
+++ b/src/main/java/org/mybatis/caches/redis/KryoSerializer.java
@@ -15,9 +15,9 @@
  */
 package org.mybatis.caches.redis;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 import java.util.Arrays;
 import java.util.Set;

--- a/src/test/java/org/mybatis/caches/redis/SerializerTestCase.java
+++ b/src/test/java/org/mybatis/caches/redis/SerializerTestCase.java
@@ -18,9 +18,6 @@ package org.mybatis.caches.redis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,19 +92,6 @@ class SerializerTestCase {
         assertEquals(rawSimpleBean, unserializeSimpleBean);
       }).start();
     }
-  }
-
-  @Test
-  void testKryoUnserializeWithoutRegistry() throws IOException {
-    SimpleBeanStudentInfo rawSimpleBean = new SimpleBeanStudentInfo();
-
-    byte[] serialBytes = kryoSerializer.serialize(rawSimpleBean);
-
-    Kryo kryoWithoutRegisty = new Kryo();
-    Input input = new Input(serialBytes);
-    SimpleBeanStudentInfo unserializeSimpleBean = (SimpleBeanStudentInfo) kryoWithoutRegisty.readClassAndObject(input);
-    assertEquals(rawSimpleBean, unserializeSimpleBean);
-
   }
 
   /**


### PR DESCRIPTION
kryo 5 changed to register by default.  See https://github.com/EsotericSoftware/kryo/issues/398

This is a security change in behaviour.  The test in question that I removed was getting an error as a result since that was true when the first portion was processed and used for input (as best I can tell).  I tried various ways to make it possible to disable that behaviour but was unnecessary and ultimately after seeing we have not released this in 8 years and its still beta, just letting it work how kryo works now.  Maybe someone using this might be able to offer more.

